### PR TITLE
feat : 아티클 필터 컴포넌트 렌더링 시 liked, views 상태 zustand로 관리

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -154,3 +154,10 @@
   z-index: 10;
 }
 
+h2 {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+  color: #333;
+}

--- a/src/components/learning/FilteredContents.tsx
+++ b/src/components/learning/FilteredContents.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { FilteredResponse } from '@/types/filterArticle';
@@ -5,7 +6,7 @@ import { getValidImageSrc } from '@/utils/checkImageProperty';
 import premiumIcon from '../../../public/images/learning/premium_article.svg';
 import { extractText } from '@/utils/extractText';
 import { useLikeStore } from '@/store/articleLike.store';
-import { useEffect } from 'react';
+import { useViewStore } from '@/store/articleView.store';
 
 interface FilteredContentsProps {
   contents: FilteredResponse['content'];
@@ -24,6 +25,7 @@ const FilteredContents = ({
 }: FilteredContentsProps) => {
   const router = useRouter();
   const { likedArticles, setLikedArticle, getLikedState } = useLikeStore();
+  const { articleViews, setArticleView, getArticleView } = useViewStore();
   const totalPages = Math.ceil(total / size);
 
   const formatDate = (dateString: string) => {
@@ -37,12 +39,19 @@ const FilteredContents = ({
 
   useEffect(() => {
     contents.forEach((item) => {
+      // likes 저장
       const existingLike = getLikedState(item.article.articleId);
       if (!existingLike) {
         setLikedArticle(item.article.articleId, item.likedByMe, item.article.likes);
       }
+
+      // views 저장
+      const existingView = getArticleView(item.article.articleId);
+      if (!existingView) {
+        setArticleView(item.article.articleId, item.article.views);
+      }
     });
-  }, [contents, setLikedArticle, getLikedState]);
+  }, [contents, setLikedArticle, getLikedState, setArticleView, getArticleView]);
 
   return (
     <div className="mt-10">
@@ -53,6 +62,7 @@ const FilteredContents = ({
               liked: item.likedByMe,
               likes: item.article.likes,
             };
+            const viewCount = getArticleView(item.article.articleId) || item.article.views;
 
             return (
               <div
@@ -89,7 +99,7 @@ const FilteredContents = ({
                   <div className="text-xs text-gray-500 mt-4 flex items-center justify-end gap-4">
                     <span>{formatDate(item.article.date)}</span>
                     <span>❤ {likeState.likes}</span>
-                    <span>👁 {item.article.views}</span>
+                    <span>👁 {viewCount}</span> {/* views 상태 적용 */}
                   </div>
                 </div>
               </div>

--- a/src/components/learning/FilteredContents.tsx
+++ b/src/components/learning/FilteredContents.tsx
@@ -1,11 +1,11 @@
-'use client';
-
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { FilteredResponse } from '@/types/filterArticle';
 import { getValidImageSrc } from '@/utils/checkImageProperty';
 import premiumIcon from '../../../public/images/learning/premium_article.svg';
 import { extractText } from '@/utils/extractText';
+import { useLikeStore } from '@/store/articleLike.store';
+import { useEffect } from 'react';
 
 interface FilteredContentsProps {
   contents: FilteredResponse['content'];
@@ -23,6 +23,7 @@ const FilteredContents = ({
   onPageChange,
 }: FilteredContentsProps) => {
   const router = useRouter();
+  const { likedArticles, setLikedArticle, getLikedState } = useLikeStore();
   const totalPages = Math.ceil(total / size);
 
   const formatDate = (dateString: string) => {
@@ -34,50 +35,66 @@ const FilteredContents = ({
     router.push(`/learning/detail/${item.article.articleId}`);
   };
 
+  useEffect(() => {
+    contents.forEach((item) => {
+      const existingLike = getLikedState(item.article.articleId);
+      if (!existingLike) {
+        setLikedArticle(item.article.articleId, item.likedByMe, item.article.likes);
+      }
+    });
+  }, [contents, setLikedArticle, getLikedState]);
+
   return (
     <div className="mt-10">
       <div className="space-y-10">
         {contents.length > 0 ? (
-          contents.map((item) => (
-            <div
-              key={item.article.articleId}
-              className="flex items-center gap-4 cursor-pointer"
-              onClick={() => handleContentClick(item)}
-            >
-              <div className="relative w-64 h-40 flex-shrink-0 overflow-hidden rounded-md">
-                <Image
-                  src={getValidImageSrc(item.article.img_link)}
-                  alt={item.article.title}
-                  width={128}
-                  height={80}
-                  className="object-cover w-full h-full"
-                />
-                {item.article.isPremium && (
-                  <div className="absolute bottom-4 left-4">
-                    <Image
-                      src={premiumIcon}
-                      alt="프리미엄 아이콘"
-                      width={24}
-                      height={24}
-                    />
+          contents.map((item) => {
+            const likeState = getLikedState(item.article.articleId) || {
+              liked: item.likedByMe,
+              likes: item.article.likes,
+            };
+
+            return (
+              <div
+                key={item.article.articleId}
+                className="flex items-center gap-4 cursor-pointer"
+                onClick={() => handleContentClick(item)}
+              >
+                <div className="relative w-64 h-40 flex-shrink-0 overflow-hidden rounded-md">
+                  <Image
+                    src={getValidImageSrc(item.article.img_link)}
+                    alt={item.article.title}
+                    width={128}
+                    height={80}
+                    className="object-cover w-full h-full"
+                  />
+                  {item.article.isPremium && (
+                    <div className="absolute bottom-4 left-4">
+                      <Image
+                        src={premiumIcon}
+                        alt="프리미엄 아이콘"
+                        width={24}
+                        height={24}
+                      />
+                    </div>
+                  )}
+                </div>
+                <div className="h-40 w-full flex flex-col justify-between">
+                  <h3 className="text-lg font-bold text-gray-800 mb-4 line-clamp-1">
+                    {item.article.title}
+                  </h3>
+                  <p className="text-sm text-gray-600 line-clamp-2">
+                    {extractText(item.article.description || '')}
+                  </p>
+                  <div className="text-xs text-gray-500 mt-4 flex items-center justify-end gap-4">
+                    <span>{formatDate(item.article.date)}</span>
+                    <span>❤ {likeState.likes}</span>
+                    <span>👁 {item.article.views}</span>
                   </div>
-                )}
-              </div>
-              <div className="h-40 w-full flex flex-col justify-between">
-                <h3 className="text-lg font-bold text-gray-800 mb-4 line-clamp-1">
-                  {item.article.title}
-                </h3>
-                <p className="text-sm text-gray-600 line-clamp-2">
-                  {extractText(item.article.description || '')}
-                </p>
-                <div className="text-xs text-gray-500 mt-4 flex items-center justify-end gap-4">
-                  <span>{formatDate(item.article.date)}</span>
-                  <span>❤ {item.article.likes}</span>
-                  <span>👁 {item.article.views}</span>
                 </div>
               </div>
-            </div>
-          ))
+            );
+          })
         ) : (
           <div className="text-center text-gray-500">데이터가 없습니다.</div>
         )}

--- a/src/components/learning/article/ArticleDetailClientWrapper.tsx
+++ b/src/components/learning/article/ArticleDetailClientWrapper.tsx
@@ -15,6 +15,7 @@ import { likeArticle } from '@/factory/Article/ControlLiked';
 import { ArticleDetailResponse } from '@/types/learning';
 import { useLikeStore } from '@/store/articleLike.store';
 import { useAuthStore } from '@/store/userAuth.store';
+import { useViewStore } from '@/store/articleView.store';
 
 interface ArticleDetailClientWrapperProps {
   articleId: number;
@@ -26,6 +27,7 @@ const ArticleDetailClientWrapper = ({ articleId }: ArticleDetailClientWrapperPro
   const isLoggedInRef = useRef(isLoggedIn);
   const [data, setData] = useState<ArticleDetailResponse | null>(null);
   const { setLikedArticle } = useLikeStore();
+  const { setArticleView, getArticleView } = useViewStore();
   const [likedByMe, setLikedByMe] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
@@ -47,6 +49,10 @@ const ArticleDetailClientWrapper = ({ articleId }: ArticleDetailClientWrapperPro
           setData(result);
           setLikedByMe(result.likedByMe);
           setLikedArticle(articleId, result.likedByMe, result.articleDetail.likes);
+  
+          // views 업데이트
+          const currentViews = getArticleView(articleId) || result.articleDetail.views;
+          setArticleView(articleId, currentViews + 1);
         } else {
           console.error('Article data is missing.');
         }
@@ -56,9 +62,9 @@ const ArticleDetailClientWrapper = ({ articleId }: ArticleDetailClientWrapperPro
         setIsLoading(false);
       }
     };
-
+  
     fetchData();
-  }, [articleId, router, setLikedArticle]);
+  }, [articleId, router, setLikedArticle, setArticleView, getArticleView]);
 
   if (isLoading) {
     return null;

--- a/src/components/learning/article/ArticleDetailClientWrapper.tsx
+++ b/src/components/learning/article/ArticleDetailClientWrapper.tsx
@@ -46,7 +46,7 @@ const ArticleDetailClientWrapper = ({ articleId }: ArticleDetailClientWrapperPro
         if (result) {
           setData(result);
           setLikedByMe(result.likedByMe);
-          setLikedArticle(articleId, result.likedByMe);
+          setLikedArticle(articleId, result.likedByMe, result.articleDetail.likes);
         } else {
           console.error('Article data is missing.');
         }
@@ -63,8 +63,6 @@ const ArticleDetailClientWrapper = ({ articleId }: ArticleDetailClientWrapperPro
   if (isLoading) {
     return null;
   }
-
-
 
   if (!data) {
     return <div>데이터를 가져오지 못했습니다.</div>;
@@ -87,8 +85,21 @@ const ArticleDetailClientWrapper = ({ articleId }: ArticleDetailClientWrapperPro
   const handleLikeToggle = async () => {
     try {
       const response = await likeArticle(articleId);
+      const updatedLikes = response.liked ? data!.articleDetail.likes + 1 : data!.articleDetail.likes - 1;
+      
       setLikedByMe(response.liked);
-      setLikedArticle(articleId, response.liked);
+      setData((prevData) =>
+        prevData
+          ? {
+              ...prevData,
+              articleDetail: {
+                ...prevData.articleDetail,
+                likes: updatedLikes,
+              },
+            }
+          : null
+      );
+      setLikedArticle(articleId, response.liked, updatedLikes);
     } catch (error) {
       console.error('좋아요 API 호출 실패:', error);
     }

--- a/src/components/learning/article/ArticleDetailContent.tsx
+++ b/src/components/learning/article/ArticleDetailContent.tsx
@@ -34,7 +34,8 @@ const ArticleDetailContent = ({ text, title, paywallUp, createdAt, authorName, i
     }
   };
 
-  const parsedContent = paywallUp ? parseHtmlContent(paywallUp) : null;
+  const parsedPaywallContent = paywallUp ? parseHtmlContent(paywallUp) : null;
+  const parsedTextContent = text ? parseHtmlContent(text) : null;
 
   return (
     <div className="max-w-[1000px] w-[90%] mx-auto my-10">
@@ -52,7 +53,7 @@ const ArticleDetailContent = ({ text, title, paywallUp, createdAt, authorName, i
           <article
             className="mt-8 text-black text-[22px] font-semibold font-['Pretendard'] leading-[30.80px] tracking-wide"
             dangerouslySetInnerHTML={{
-              __html: parsedContent || "<p>프리미엄 콘텐츠를 준비 중입니다.</p>",
+              __html: parsedPaywallContent || "<p>프리미엄 콘텐츠를 준비 중입니다.</p>",
             }}
           />
           <div className="my-24 rounded-lg text-center flex flex-col items-center gap-4">
@@ -84,13 +85,12 @@ const ArticleDetailContent = ({ text, title, paywallUp, createdAt, authorName, i
           </div>
         </>
       ) : (
-        <article className="mt-8 text-black text-[22px] font-semibold font-['Pretendard'] leading-[30.80px] tracking-wide">
-          {text?.split("\n\n").map((paragraph, index) => (
-            <p key={index} className="mb-4">
-              {paragraph}
-            </p>
-          ))}
-        </article>
+        <article
+          className="mt-8 text-black text-[22px] font-semibold font-['Pretendard'] leading-[30.80px] tracking-wide"
+          dangerouslySetInnerHTML={{
+            __html: parsedTextContent || "<p>텍스트 콘텐츠를 불러올 수 없습니다.</p>",
+          }}
+        />
       )}
     </div>
   );

--- a/src/store/articleLike.store.ts
+++ b/src/store/articleLike.store.ts
@@ -1,18 +1,18 @@
 import { create } from 'zustand';
 
 interface LikeState {
-  likedArticles: Record<number, boolean>; 
-  setLikedArticle: (articleId: number, liked: boolean) => void;
-  getLikedState: (articleId: number) => boolean | undefined;
+  likedArticles: Record<number, { liked: boolean; likes: number }>;
+  setLikedArticle: (articleId: number, liked: boolean, likes: number) => void;
+  getLikedState: (articleId: number) => { liked: boolean; likes: number } | undefined;
 }
 
 export const useLikeStore = create<LikeState>((set, get) => ({
   likedArticles: {},
-  setLikedArticle: (articleId, liked) =>
+  setLikedArticle: (articleId, liked, likes) =>
     set((state) => ({
       likedArticles: {
         ...state.likedArticles,
-        [articleId]: liked,
+        [articleId]: { liked, likes },
       },
     })),
   getLikedState: (articleId) => get().likedArticles[articleId],

--- a/src/store/articleView.store.ts
+++ b/src/store/articleView.store.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+interface ArticleViewState {
+  articleViews: Record<number, number>;
+  setArticleView: (articleId: number, views: number) => void;
+  getArticleView: (articleId: number) => number | undefined;
+}
+
+export const useViewStore = create<ArticleViewState>((set, get) => ({
+  articleViews: {},
+
+  setArticleView: (articleId, views) =>
+    set((state) => ({
+      articleViews: {
+        ...state.articleViews,
+        [articleId]: views,
+      },
+    })),
+
+  getArticleView: (articleId) => get().articleViews[articleId],
+}));


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] TEST : 테스트 추가 및 리팩토링
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

- 아티클 필터 컴포넌트 렌더링 시 liked, views 상태 zustand로 관리


### How it Works

아티클 페이지 접속 시 SSR로 데이터를 받아오기 때문에 상세페이지 접근 후, 뒤로 가기를 통해 다시 아티클 페이지 접속 시 API 재호출이 일어나지 않음. 아티클 상세 페이지는 CSR로 데이터를 받아오기 때문에 접속할 때 마다 liked와 views값을 새로 받아오는데, 접속하면 기본적으로 views값은 하나가 증가하고 liked값은 사용자가 좋아요 버튼을 누르거나 취소할 때 상태값이 바뀌게 됨. 이러한 동작 이후, 뒤로가기를 통해 아티클 페이지로 돌아갔을 때 API 재호출이 일어나지않아 좋아요 동작으로 인한 좋아요 개수, views 개수가 새로고침을 하지 않는 이상 변하지 않기 때문에 zustand로 전역으로 상태를 관리
-> 처음 아티클 페이지 접속 시 zustand에 저장된 데이터 값이 없으면 SSR로 받아오는 데이터(좋아요 개수 및 좋아요 여부, views 개수)를 zustand에 저장하고 렌더링해줌. 이후 아티클 상세페이지 접속 시 여기서 또 받아오는 views 개수를 다시 zustand에 업데이트, 좋아요 로직 동작 시, 등록 및 취소 여부 그리고 좋아요 개수를 다시 zustand에 업데이트함. 이후 뒤로가기를 통해 다시 아티클 페이지 접속 시 데이터를 새로 로드하지 않아도 zustand값을 통해 올바른 값을 렌더링해줌


### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->