### PR TITLE
feat: 아티클 상세페이지 모바일 레이아웃 작업 및 좋아요 상태 오류 해결

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,6 +33,10 @@
   display: inline-block;
 }
 
+.swiper-pagination-bullet-active {
+  background-color: black !important;
+}
+
 .mySwiper .swiper-pagination-bullet-active {
   background-color: black;
 }

--- a/src/app/learning/detail/[articleId]/page.tsx
+++ b/src/app/learning/detail/[articleId]/page.tsx
@@ -11,9 +11,9 @@ export default function ArticleDetailPage({ params }: PageProps) {
   const articleId = params.articleId;
 
   return (
-    <>
+    <div className='min-h-[calc(100dvh-135.5px)] flex flex-col'>
       <Navbar />
       <ArticleDetailClientWrapper articleId={Number(articleId)} />
-    </>
+    </div>
   );
 }

--- a/src/app/learning/page.tsx
+++ b/src/app/learning/page.tsx
@@ -28,7 +28,7 @@ const LearningPage = async () => {
   const initialData = await response.json();
 
   return (
-    <div>
+    <div className='min-h-[calc(100dvh-135.5px)] flex flex-col'>
       <Navbar />
       <LearningPageClient initialData={initialData} />
     </div>

--- a/src/components/learning/FilteredContents.tsx
+++ b/src/components/learning/FilteredContents.tsx
@@ -70,7 +70,7 @@ const FilteredContents = ({
                 className="flex items-center gap-4 cursor-pointer"
                 onClick={() => handleContentClick(item)}
               >
-                <div className="relative w-64 h-40 flex-shrink-0 overflow-hidden rounded-md">
+                <div className="relative w-28 h-28 sm:w-64 sm:h-40 flex-shrink-0 overflow-hidden rounded-md">
                   <Image
                     src={getValidImageSrc(item.article.img_link)}
                     alt={item.article.title}
@@ -89,7 +89,7 @@ const FilteredContents = ({
                     </div>
                   )}
                 </div>
-                <div className="h-40 w-full flex flex-col justify-between">
+                <div className="h-28 sm:h-40 w-full flex flex-col justify-between">
                   <h3 className="text-lg font-bold text-gray-800 mb-4 line-clamp-1">
                     {item.article.title}
                   </h3>
@@ -99,7 +99,7 @@ const FilteredContents = ({
                   <div className="text-xs text-gray-500 mt-4 flex items-center justify-end gap-4">
                     <span>{formatDate(item.article.date)}</span>
                     <span>❤ {likeState.likes}</span>
-                    <span>👁 {viewCount}</span> {/* views 상태 적용 */}
+                    <span>👁 {viewCount}</span> 
                   </div>
                 </div>
               </div>
@@ -111,7 +111,7 @@ const FilteredContents = ({
       </div>
 
       {totalPages > 1 && (
-        <div className="flex justify-center mt-8">
+        <div className="flex justify-center mt-8 mb-2">
           <ul className="flex items-center space-x-1">
             {Array.from({ length: totalPages }, (_, i) => i + 1).map(
               (pageNum) => (

--- a/src/components/learning/LatestNewsClipping.tsx
+++ b/src/components/learning/LatestNewsClipping.tsx
@@ -59,7 +59,7 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
                 alt={contents[0].title}
                 width={600}
                 height={300}
-                className="w-full h-48 object-cover rounded-lg"
+                className="w-full h-48 object-cover"
               />
               <div className="absolute bottom-4 right-4">
                 <Image
@@ -76,19 +76,19 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
               </div>
               </div>
               <div className="bg-white w-[90%] sm:w-[100%] mx-auto pt-4">
+                <div className="w-full justify-between mb-1">
+                    <span
+                      className="rounded-full text-xs font-medium bg-[#ececec] text-[#8a8a8a] px-2 py-1"
+                      style={{ display: 'inline-flex', maxWidth: 'fit-content' }}
+                    >
+                      {contents[0].type || '카테고리'}
+                    </span>
+                    <div>{contents[0].date}</div>
+                  </div>
                 <h3 className="text-lg font-bold">{contents[0].title}</h3>
-                <p className="text-gray-600 text-sm mt-2 line-clamp-2">
+                <p className="text-gray-600 text-sm my-2 line-clamp-2">
                   {extractText(contents[0].description || "")}
                 </p>
-                <div className="w-full justify-between">
-                  <span
-                    className="text-xs text-gray-600 px-2 py-1 rounded-full bg-gray-200"
-                    style={{ display: 'inline-flex', maxWidth: 'fit-content' }}
-                  >
-                    {contents[0].type || '카테고리'}
-                  </span>
-                  <div>{contents[0].date}</div>
-                </div>
               </div>
             </div>
           )}
@@ -122,19 +122,19 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
                   </div>
                 </div>
                 <div className="flex-1 flex flex-col justify-center">
-                  <h3 className="text-sm font-bold line-clamp-1">{content.title}</h3>
-                  <p className="text-gray-600 text-xs my-1 line-clamp-2">
-                    {extractText(content.description || "")}
-                  </p>
-                  <div className="w-full justify-between">
+                <div className="w-full justify-between">
                     <span
-                      className="text-xs text-gray-600 px-2 py-1 rounded-full bg-gray-200"
+                      className="rounded-full text-xs font-medium bg-[#ececec] text-[#8a8a8a] px-2 py-1"
                       style={{ display: 'inline-flex', maxWidth: 'fit-content' }}
                     >
                       {content.type || '카테고리'}
                     </span>
                     <div>{content.date}</div>
                   </div>
+                  <h3 className="text-sm font-bold line-clamp-1">{content.title}</h3>
+                  <p className="text-gray-600 text-xs mt-1 line-clamp-2">
+                    {extractText(content.description || "")}
+                  </p>
                 </div>
               </div>
             ))}
@@ -189,7 +189,7 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
             </div>
           </div>
           )}
-          <div className="flex flex-col gap-6 w-1/2">
+          <div className="flex flex-col gap-[1.6rem] w-1/2">
             {contents.slice(1, 5).map((content, index) => (
                <div key={index} className="flex items-stretch gap-4 cursor-pointer"
                   onClick={() => handleContentClick(content)}
@@ -228,13 +228,13 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
                 </div>
                 <div className="flex-1 flex flex-col justify-between">
                   <span
-                      className="text-xs text-gray-600 px-2 py-1 rounded-full bg-gray-200"
+                      className="rounded-full text-xs font-medium bg-[#ececec] text-[#8a8a8a] px-2 py-1"
                       style={{ display: 'inline-flex', maxWidth: 'fit-content' }}
                     >
                       {content.type || '카테고리'}
                     </span>
-                  <h3 className="text-md font-bold line-clamp-2">{content.title}</h3>
-                  <p className="text-sm text-gray-600 line-clamp-2 mt-1">
+                  <h3 className="text-md font-bold line-clamp-2 my-1">{content.title}</h3>
+                  <p className="text-xs text-gray-600 line-clamp-2">
                     {extractText(content.description || "")}
                   </p>
                 </div>

--- a/src/components/learning/LatestNewsClipping.tsx
+++ b/src/components/learning/LatestNewsClipping.tsx
@@ -49,6 +49,7 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
       {isMobile ? (
         <div className="sm:hidden">
           {contents[0] && (
+            
             <div
               className="w-full overflow-hidden mb-4 cursor-pointer relative"
               onClick={() => handleContentClick(contents[0])}
@@ -62,18 +63,20 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
                 className="w-full h-48 object-cover"
               />
               <div className="absolute bottom-4 right-4">
-                <Image
-                  src={
-                    getLikedState(contents[0].articleId) ?? contents[0].likedByMe
-                      ? likedIcon
-                      : noLikedIcon
-                  }
-                  alt="좋아요 아이콘"
-                  width={24}
-                  height={24}
-                  className="cursor-pointer"
-                />
-              </div>
+                  {(() => {
+                    const likedByMe = getLikedState(contents[0].articleId) ?? contents[0].likedByMe;
+                    const likedStatus = likedByMe?.liked ?? contents[0].likedByMe;
+                    return (
+                      <Image
+                        src={likedStatus ? likedIcon : noLikedIcon}
+                        alt={likedStatus ? 'Liked' : 'Not Liked'}
+                        width={24}
+                        height={24}
+                        className="cursor-pointer"
+                      />
+                    );
+                  })()}
+                </div>
               </div>
               <div className="bg-white w-[90%] sm:w-[100%] mx-auto pt-4">
                 <div className="w-full justify-between mb-1">
@@ -108,17 +111,19 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
                     className="w-full h-full object-cover"
                   />
                   <div className="absolute bottom-2 right-2">
-                    <Image
-                      src={
-                        getLikedState(content.articleId) ?? content.likedByMe
-                          ? likedIcon
-                          : noLikedIcon
-                      }
-                      alt="좋아요 아이콘"
-                      width={16}
-                      height={16}
-                      className="cursor-pointer"
-                    />
+                    {(() => {
+                      const likedByMe = getLikedState(content.articleId) ?? content.likedByMe;
+                      const likedStatus = likedByMe?.liked ?? content.likedByMe;
+                      return (
+                        <Image
+                          src={likedStatus ? likedIcon : noLikedIcon}
+                          alt={likedStatus ? 'Liked' : 'Not Liked'}
+                          width={16}
+                          height={16}
+                          className="cursor-pointer"
+                        />
+                      );
+                    })()}
                   </div>
                 </div>
                 <div className="flex-1 flex flex-col justify-center">
@@ -170,18 +175,20 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
                     </div>
                   )}
                 <div className="absolute bottom-4 right-4">
-                <Image
-                  src={
-                    getLikedState(contents[0].articleId) ?? contents[0].likedByMe
-                      ? likedIcon
-                      : noLikedIcon
-                  }
-                  alt="좋아요 아이콘"
-                  width={24}
-                  height={24}
-                  className="cursor-pointer"
-                />
-              </div>
+                  {(() => {
+                    const likedByMe = getLikedState(contents[0].articleId) ?? contents[0].likedByMe;
+                    const likedStatus = likedByMe?.liked ?? contents[0].likedByMe;
+                    return (
+                      <Image
+                        src={likedStatus ? likedIcon : noLikedIcon}
+                        alt={likedStatus ? 'Liked' : 'Not Liked'}
+                        width={24}
+                        height={24}
+                        className="cursor-pointer"
+                      />
+                    );
+                  })()}
+                </div>
             </div>
             <div className="bg-white p-6 flex flex-col justify-between flex-grow">
               <h3 className="text-xl font-bold">{contents[0].title}</h3>
@@ -212,18 +219,20 @@ const LatestNewsClipping = ({ contents }: { contents: any[] }) => {
                         />
                       </div>
                     )}
-                  <div className="absolute bottom-2 right-2">
-                    <Image
-                      src={
-                        getLikedState(content.articleId) ?? content.likedByMe
-                          ? likedIcon
-                          : noLikedIcon
-                      }
-                      alt="좋아요 아이콘"
-                      width={16}
-                      height={16}
-                      className="cursor-pointer"
-                    />
+                <div className="absolute bottom-2 right-2">
+                    {(() => {
+                      const likedByMe = getLikedState(content.articleId) ?? content.likedByMe;
+                      const likedStatus = likedByMe?.liked ?? content.likedByMe;
+                      return (
+                        <Image
+                          src={likedStatus ? likedIcon : noLikedIcon}
+                          alt={likedStatus ? 'Liked' : 'Not Liked'}
+                          width={16}
+                          height={16}
+                          className="cursor-pointer"
+                        />
+                      );
+                    })()}
                   </div>
                 </div>
                 <div className="flex-1 flex flex-col justify-between">

--- a/src/components/learning/LearningPageClient.tsx
+++ b/src/components/learning/LearningPageClient.tsx
@@ -249,7 +249,7 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
         </div>
       </div>
 
-      <div className="max-w-[360px] mx-auto desk:max-w-[1000px] w-full sm:w-[90%] lg:w-[100%] mt-8">
+      <div className="max-w-[360px] mx-auto desk:max-w-[1000px] w-[90%] lg:w-[100%] mt-8">
         {!selectedType && !selectedCategory ? (
           <>
             <PopularContents contents={extractContents(initialData.popularContents)} />

--- a/src/components/learning/LearningPageClient.tsx
+++ b/src/components/learning/LearningPageClient.tsx
@@ -80,7 +80,7 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
 
   return (
     <div>
-      <div className="relative w-full h-[300px] lg:h-[400px]">
+      <div className="hidden sm:flex relative w-full h-[300px] lg:h-[400px]">
         <Image
           src={BackgroundImage}
           alt="Background"
@@ -169,6 +169,83 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
               )}
             </div>
           </div>
+        </div>
+      </div>
+
+      <div className="relative z-50 bg-white sm:hidden">
+        <button
+          onClick={() => setActiveDropdown(activeDropdown === 'mobile' ? null : 'mobile')}
+          className="w-full px-4 py-4 text-lg font-semibold flex justify-between items-center border-b border-gray-200"
+        >
+          {selectedCategory
+            ? dropdownOptions.category.find((o) => o.value === selectedCategory)?.label
+            : '학습하기'}
+          <Image
+            src={ArrowIcon}
+            alt="Arrow Icon"
+            width={12}
+            height={12}
+            className={`transition-transform duration-300 ${
+              activeDropdown === 'mobile' ? 'rotate-180' : ''
+            }`}
+          />
+        </button>
+        {activeDropdown === 'mobile' && (
+          <div className="absolute left-0 w-full bg-white shadow-lg z-50">
+            {selectedCategory !== '' && (
+              <div>
+                <button
+                  onClick={() => {
+                    resetFilters(); 
+                    setActiveDropdown(null); 
+                  }}
+                  className="w-full px-4 py-2 text-start text-gray-700 hover:bg-gray-100 border-b"
+                >
+                  학습하기
+                </button>
+              </div>
+            )}
+
+            <div>
+              {dropdownOptions.category
+                .filter((option) => option.value !== selectedCategory)
+                .map((option) => (
+                  <button
+                    key={option.value}
+                    onClick={() => {
+                      handleCategoryChange(option.value);
+                      setActiveDropdown(null); 
+                    }}
+                    className="w-full px-4 py-2 text-start text-gray-700 hover:bg-gray-100 border-b last:border-b-0"
+                  >
+                    {option.label}
+                  </button>
+                ))}
+            </div>
+          </div>
+        )}
+
+        <div
+          className={`flex justify-around border-b border-gray-200 z-10 relative ${
+            activeDropdown === 'mobile' ? 'pointer-events-none' : ''
+          }`}
+        >
+          {dropdownOptions.type.map((option) => (
+            <button
+              key={option.value}
+              onClick={() => {
+                handleTypeChange(option.value);
+                setActiveDropdown(null);
+              }}
+              className={`px-4 py-2 text-lg font-medium ${
+                selectedType === option.value
+                  ? 'text-purple-600 border-b-2 border-purple-600'
+                  : 'text-gray-500'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
         </div>
       </div>
 

--- a/src/components/learning/LearningPageClient.tsx
+++ b/src/components/learning/LearningPageClient.tsx
@@ -175,7 +175,7 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
       <div className="relative z-50 bg-white sm:hidden">
         <button
           onClick={() => setActiveDropdown(activeDropdown === 'mobile' ? null : 'mobile')}
-          className="w-full px-4 py-4 text-lg font-semibold flex justify-between items-center border-b border-gray-200"
+          className="w-full px-6 py-4 text-lg font-semibold flex items-center"
         >
           {selectedCategory
             ? dropdownOptions.category.find((o) => o.value === selectedCategory)?.label
@@ -183,9 +183,9 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
           <Image
             src={ArrowIcon}
             alt="Arrow Icon"
-            width={12}
-            height={12}
-            className={`transition-transform duration-300 ${
+            width={16}
+            height={16}
+            className={`transition-transform duration-300 ml-[10px] ${
               activeDropdown === 'mobile' ? 'rotate-180' : ''
             }`}
           />
@@ -199,7 +199,7 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
                     resetFilters(); 
                     setActiveDropdown(null); 
                   }}
-                  className="w-full px-4 py-2 text-start text-gray-700 hover:bg-gray-100 border-b"
+                  className="w-full px-6 py-4 text-start text-[#a2a5aa] text-base hover:bg-gray-100 border-b"
                 >
                   학습하기
                 </button>
@@ -216,7 +216,7 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
                       handleCategoryChange(option.value);
                       setActiveDropdown(null); 
                     }}
-                    className="w-full px-4 py-2 text-start text-gray-700 hover:bg-gray-100 border-b last:border-b-0"
+                    className="w-full px-6 py-4 text-start text-[#a2a5aa] text-base hover:bg-gray-100 border-b last:border-b-0"
                   >
                     {option.label}
                   </button>
@@ -226,7 +226,7 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
         )}
 
         <div
-          className={`flex justify-around border-b border-gray-200 z-10 relative ${
+          className={`flex border-b border-gray-200 z-10 relative ${
             activeDropdown === 'mobile' ? 'pointer-events-none' : ''
           }`}
         >
@@ -237,10 +237,10 @@ const LearningPageClient = ({ initialData }: { initialData: OverviewResponse }) 
                 handleTypeChange(option.value);
                 setActiveDropdown(null);
               }}
-              className={`px-4 py-2 text-lg font-medium ${
-                selectedType === option.value
-                  ? 'text-purple-600 border-b-2 border-purple-600'
-                  : 'text-gray-500'
+              className={`px-4 mx-4 py-2 text-lg font-medium ${
+                selectedCategory && selectedType === option.value
+                  ? 'text-[#1e1e1e] text-base font-bold border-b-2 border-[#6F36E8]'
+                  : 'text-[#a2a5aa] text-base font-bold'
               }`}
             >
               {option.label}

--- a/src/components/learning/PopularContents.tsx
+++ b/src/components/learning/PopularContents.tsx
@@ -56,7 +56,8 @@ const PopularContents = ({ contents }: { contents: any[] }) => {
             >
               {contents.map((content, index) => {
                 const likedByMe = getLikedState(content.articleId) ?? content.likedByMe;
-
+                const likedStatus = likedByMe?.liked ?? content.likedByMe;
+ 
                 return (
                   <SwiperSlide key={index}>
                     <div
@@ -97,8 +98,8 @@ const PopularContents = ({ contents }: { contents: any[] }) => {
                         )}
                         <div className="absolute bottom-4 right-4">
                         <Image
-                          src={likedByMe ? likedIcon : noLikedIcon}
-                          alt={likedByMe ? 'Liked' : 'Not Liked'}
+                          src={likedStatus ? likedIcon : noLikedIcon}
+                          alt={likedStatus ? 'Liked' : 'Not Liked'}
                           width={24}
                           height={24}
                         />
@@ -122,7 +123,8 @@ const PopularContents = ({ contents }: { contents: any[] }) => {
           <div className="hidden sm:grid gap-4 relative z-10">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               {contents.map((content, index) => {
-                const likedByMe = getLikedState(content.articleId) ?? content.likedByMe;
+               const likedByMe = getLikedState(content.articleId) ?? content.likedByMe;
+               const likedStatus = likedByMe?.liked ?? content.likedByMe;
 
                 return (
                   <div
@@ -149,8 +151,8 @@ const PopularContents = ({ contents }: { contents: any[] }) => {
                         )}
                        <div className="absolute bottom-4 right-4">
                       <Image
-                        src={likedByMe ? likedIcon : noLikedIcon}
-                        alt={likedByMe ? 'Liked' : 'Not Liked'}
+                        src={likedStatus ? likedIcon : noLikedIcon}
+                        alt={likedStatus ? 'Liked' : 'Not Liked'}
                         width={24}
                         height={24}
                       />

--- a/src/components/learning/PopularContents.tsx
+++ b/src/components/learning/PopularContents.tsx
@@ -156,12 +156,12 @@ const PopularContents = ({ contents }: { contents: any[] }) => {
                       />
                     </div>
                     </div>
-                    <div className="flex items-center gap-2 px-4 py-2">
+                    <div className="flex items-center gap-2 px-3 py-2">
                       <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-[#ececec] text-[#8a8a8a]">
                         {content.type}
                       </span>
                       <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-[#f4e5ff] text-[#6e35e8]">
-                        {content.categoryName || '카테고리'}
+                        {content.categoryName?.replace(/[^a-zA-Z0-9가-힣\s]/g, '') || '카테고리'}
                       </span>
                     </div>
                     <div className="flex flex-col flex-grow px-4">

--- a/src/components/learning/PopularContents.tsx
+++ b/src/components/learning/PopularContents.tsx
@@ -83,7 +83,7 @@ const PopularContents = ({ contents }: { contents: any[] }) => {
                             {content.type}
                           </span>
                           <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-[#f4e5ff] text-[#6e35e8]">
-                            {content.categoryName || '카테고리'}
+                            {content.categoryName.replace(/[^a-zA-Z0-9가-힣\s]/g, '') || '카테고리'}
                           </span>
                         </div>
                         {content.premium && (

--- a/src/components/learning/RecentContents.tsx
+++ b/src/components/learning/RecentContents.tsx
@@ -134,12 +134,12 @@ const RecentContents = ({ contents }: { contents: any[] }) => {
                         />
                       </div>
                     </div>
-                    <div className="flex items-center gap-2 px-4 py-2">
+                    <div className="flex items-center gap-2 px-3 py-2">
                       <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-[#ececec] text-[#8a8a8a]">
                         {content.type}
                       </span>
                       <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-[#f4e5ff] text-[#6e35e8]">
-                        {content.categoryName || '카테고리'}
+                        {content.categoryName?.replace(/[^a-zA-Z0-9가-힣\s]/g, '') || '카테고리'}
                       </span>
                     </div>
                     <div className="flex flex-col flex-grow px-4">

--- a/src/components/learning/RecentContents.tsx
+++ b/src/components/learning/RecentContents.tsx
@@ -58,6 +58,7 @@ const RecentContents = ({ contents }: { contents: any[] }) => {
             >
               {contents.map((content, index) => {
                 const likedByMe = getLikedState(content.articleId) ?? content.likedByMe;
+                const likedStatus = likedByMe?.liked ?? content.likedByMe;
 
                 return (
                   <SwiperSlide key={index} className="relative">
@@ -83,8 +84,8 @@ const RecentContents = ({ contents }: { contents: any[] }) => {
                       </div>
                       <div className="absolute bottom-6 right-4">
                         <Image
-                          src={likedByMe ? likedIcon : noLikedIcon}
-                          alt={likedByMe ? 'Liked' : 'Not Liked'}
+                          src={likedStatus ? likedIcon : noLikedIcon}
+                          alt={likedStatus ? 'Liked' : 'Not Liked'}
                           width={24}
                           height={24}
                         />
@@ -101,6 +102,7 @@ const RecentContents = ({ contents }: { contents: any[] }) => {
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               {contents.map((content, index) => {
                 const likedByMe = getLikedState(content.articleId) ?? content.likedByMe;
+                const likedStatus = likedByMe?.liked ?? content.likedByMe;
 
                 return (
                   <div
@@ -127,8 +129,8 @@ const RecentContents = ({ contents }: { contents: any[] }) => {
                         )}
                       <div className="absolute bottom-4 right-4">
                         <Image
-                          src={likedByMe ? likedIcon : noLikedIcon}
-                          alt={likedByMe ? 'Liked' : 'Not Liked'}
+                          src={likedStatus ? likedIcon : noLikedIcon}
+                          alt={likedStatus ? 'Liked' : 'Not Liked'}
                           width={24}
                           height={24}
                         />

--- a/src/components/learning/article/ArticleDetailClientWrapper.tsx
+++ b/src/components/learning/article/ArticleDetailClientWrapper.tsx
@@ -122,7 +122,7 @@ const ArticleDetailClientWrapper = ({ articleId }: ArticleDetailClientWrapperPro
       />
       <div className="max-w-[1000px] w-[90%] mx-auto py-8 flex items-center justify-between border-b border-[#ececec]">
         <div className="text-sm text-[#a0a0a0]">
-          학습하기 &gt; 아티클 &gt; {articleDetail?.categoryName || '카테고리 없음'}
+          학습하기 &gt; 아티클 &gt; {articleDetail?.categoryName.replace(/[^a-zA-Z0-9가-힣\s]/g, '') || '카테고리 없음'}
         </div>
         <div className="flex items-center gap-4 z-[9999]">
           <Image

--- a/src/components/learning/article/ArticleDetailClientWrapper.tsx
+++ b/src/components/learning/article/ArticleDetailClientWrapper.tsx
@@ -48,7 +48,7 @@ const ArticleDetailClientWrapper = ({ articleId }: ArticleDetailClientWrapperPro
         if (result) {
           setData(result);
           setLikedByMe(result.likedByMe);
-          setLikedArticle(articleId, result.likedByMe, result.articleDetail.likes);
+          // setLikedArticle(articleId, result.likedByMe, result.articleDetail.likes);
   
           // views 업데이트
           const currentViews = getArticleView(articleId) || result.articleDetail.views;

--- a/src/components/learning/article/ArticleDetailHeader.tsx
+++ b/src/components/learning/article/ArticleDetailHeader.tsx
@@ -22,9 +22,9 @@ const ArticleDetailHeader = ({ categoryName, title, createdAt, authorName, imgLi
       />
       {/* todo: 모바일 작업 */}
       <div className="absolute inset-0 bg-black/50 flex flex-col justify-center items-center text-white">
-        <p className="text-center text-[#fffffc]/80 text-2xl font-medium font-['Pretendard'] leading-[33.60px] ">{categoryName}</p>
+        <p className="text-center text-[#fffffc]/80 text-2xl font-medium font-['Pretendard'] leading-[33.60px] ">{categoryName.replace(/[^a-zA-Z0-9가-힣\s]/g, '')}</p>
         <hr className="w-16 border-t-2 border-white my-4" />
-        <h1 className="text-center text-white text-[40px] font-bold font-['Pretendard'] leading-[56px]">{title}</h1>
+        <h1 className="w-[90%] mx-auto text-center text-white text-[32px] font-bold font-['Pretendard'] leading-[56px]">{title}</h1>
       </div>
     </div>
   );

--- a/src/components/skeleton/LatestNewsClippingSkeleton.tsx
+++ b/src/components/skeleton/LatestNewsClippingSkeleton.tsx
@@ -16,7 +16,7 @@ const LatestNewsClippingSkeleton = () => {
             <div className="h-4 bg-gray-200 rounded-md w-full" />
           </div>
         </div>
-        <div className="flex flex-col gap-6 w-1/2">
+        <div className="flex flex-col gap-[2rem] w-1/2">
           {Array.from({ length: 4 }).map((_, index) => (
             <div
               key={index}
@@ -24,8 +24,9 @@ const LatestNewsClippingSkeleton = () => {
             >
               <div className="w-32 h-20 bg-gray-300 rounded-lg" />
               <div className="flex-1 flex flex-col justify-between">
+                <div className="h-4 bg-gray-200 rounded-md mb-2 w-1/5" />
                 <div className="h-4 bg-gray-200 rounded-md mb-2 w-2/3" />
-                <div className="h-4 bg-gray-200 rounded-md w-1/2" />
+                <div className="h-8 bg-gray-200 rounded-md w-full" />
               </div>
             </div>
           ))}
@@ -33,7 +34,7 @@ const LatestNewsClippingSkeleton = () => {
       </div>
       <div className="sm:hidden">
         <div className="w-full overflow-hidden mb-4 animate-pulse">
-          <div className="bg-gray-300 w-full h-48 rounded-lg" />
+          <div className="bg-gray-300 w-full h-48" />
           <div className="bg-white w-[90%] sm:w-[100%] mx-auto pt-4">
             <div className="h-6 bg-gray-200 rounded-md w-3/4 mb-2" />
             <div className="h-4 bg-gray-200 rounded-md w-full" />

--- a/src/components/skeleton/PopularContentsSkeleton.tsx
+++ b/src/components/skeleton/PopularContentsSkeleton.tsx
@@ -20,7 +20,7 @@ const PopularContentsSkeleton = () => {
                 className="border rounded-lg shadow-sm overflow-hidden flex flex-col bg-gray-100 animate-pulse"
               >
                 <div className="relative w-full h-[180px] bg-gray-300" />
-                <div className="flex items-center gap-2 px-4 py-2">
+                <div className="flex items-center gap-2 px-3 py-2">
                   <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-gray-200 text-gray-400 w-12 h-4" />
                   <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-gray-200 text-gray-400 w-16 h-4" />
                 </div>

--- a/src/components/skeleton/RecentContentsSkeleton.tsx
+++ b/src/components/skeleton/RecentContentsSkeleton.tsx
@@ -18,7 +18,7 @@ const RecentContentsSkeleton = () => {
                 className="border rounded-lg shadow-sm overflow-hidden flex flex-col bg-gray-100 animate-pulse"
               >
                 <div className="relative w-full h-[180px] bg-gray-300" />
-                <div className="flex items-center gap-2 px-4 py-2">
+                <div className="flex items-center gap-2 px-3 py-2">
                   <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-gray-200 text-gray-400 w-12 h-4" />
                   <span className="px-3 py-1.5 rounded-full text-xs font-medium bg-gray-200 text-gray-400 w-16 h-4" />
                 </div>

--- a/src/utils/dropdownOptions.ts
+++ b/src/utils/dropdownOptions.ts
@@ -6,8 +6,8 @@ export const dropdownOptions = {
   ],
   category: [
     { label: '전체', value: 'all' },
-    { label: '이 달의 인기 콘텐츠', value: 'popular' },
-    { label: '최신 콘텐츠', value: 'speed' },
+    // { label: '이 달의 인기 콘텐츠', value: 'popular' },
+    // { label: '최신 콘텐츠', value: 'speed' },
     { label: '오늘의 뉴스', value: 'news' },
     { label: '조각투자 기초 가이드', value: 'guide' },
     { label: '부동산', value: 'building' },


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] TEST : 테스트 추가 및 리팩토링
- [x] FIX : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] STYLE : 코드 스타일에 관련된 변경 사항
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] CHORE : 패키지 매니저 설정, 코드 수정 없이 설정 변경(eslint) 등 기타 사항

## 설명

https://github.com/user-attachments/assets/d90070cc-0781-47b4-9f7a-798bb6ec940b


아티클 상세페이지 추가 모바일 작업 진행 및 좋아요 상태 오류 해결

<!-- 어떤 작업을 했는지 -->
- 아티클 카테고리 이모티콘 정규식 사용으로 제거
- 아티클 페이지, 아티클 상세페이지 모바일 작업
- 아티클 페이지 모바일 카테고리 셀렉터 작업
- 아티클 좋아요 상태 관리 로직 수정

### How it Works
![스크린샷 2025-02-02 오전 2 40 30](https://github.com/user-attachments/assets/880f6dfd-c634-47cf-86d1-fddc28b1b430)

아티클 페이지에서 SSR로 데이터를 받아온 후 각 컴포넌트에 props로 데이터를 전달.<br/>
`const likedByMe = getLikedState(content.articleId) ?? content.likedByMe;`
이 코드를 통해 먼저 zustand에 좋아요 상태가 있으면 가져오고 없으면 props로 전달받은 값을 통해 좋아요 상태에 따라 아이콘 렌더링.
처음에 페이지 접속 시에는 zustand값에 아무것도 없으므로 props로 전달받은 값을 통해 아이콘 렌더링함.<br/>
![스크린샷 2025-02-02 오전 2 44 51](https://github.com/user-attachments/assets/91e68772-1e2d-4bb7-b65d-c3a9ddb0af2b)
해당 콘솔에서는 다음과 같이 나옴(아티클 ID, likedByMe, likedStatus) -> (상세페이지에서 좋아요 상태를 변경안했을 때).
이후 상세페이지에서 articleId 5번 객체를 좋아요 상태를 변경하고 다시 이 페이지에 오게되면, <br/>
![스크린샷 2025-02-02 오전 2 46 30](https://github.com/user-attachments/assets/989e3033-89ef-42f8-9cfe-9119964ba79e) <br/>
위 사진처럼 likedByMe 값이 객체 형태로 들어감. 좋아요 개수도 반영하는 이유는, 
![스크린샷 2025-02-02 오전 2 47 34](https://github.com/user-attachments/assets/47213a78-5459-4ced-856c-7a2e6a98a341) <br/>
위 사진처럼 컨텐츠 필터를 걸었을 때는 좋아요 개수도 렌더링하기 때문.<br/>
따라서 상세페이지에서 좋아요 상태를 변경하게 되었을 때는 likedByMe값이 객체로 들어가기 때문에,
아티클 페이지에서 좋아요 아이콘 렌더링 시 다음 사진처럼 여러 단계로 구분.
![스크린샷 2025-02-02 오전 2 45 30](https://github.com/user-attachments/assets/53aac75f-1ab6-4922-b0db-0fcfa1c21f34)



### To Reviewers
<!-- 애매하거나 같이 얘기해보고 싶은 부분 -->
- 피그마 아티클 페이지 모바일 부분은 필터링 걸렸을 때 무한스크롤로 한 줄에 2개씩 데이터가 들어가는 디자인인데, 필터링 시 페이지네이션으로 API가 구현되어있음
- 인기 컨텐츠, 최신 컨텐츠 필터링 값이 일치하지않아서 임시 주석 처리
- 피그마 아티클 페이지 데스크탑 버전은 각 카테고리마다 이미지 변경 및 텍스트 변경이 나타나는데, 디자인 X